### PR TITLE
Fix for saving message id

### DIFF
--- a/src/Listeners/CreateMailViewerItem.php
+++ b/src/Listeners/CreateMailViewerItem.php
@@ -40,7 +40,7 @@ class CreateMailViewerItem
 
         return [
             'date' => $headers->get('date'),
-            'message-id' => $headers->get('message-id')->getIds(),
+            'message-id' => $headers->get('message-id')?->getIds(),
             'from' => $headers->get('from'),
         ];
     }

--- a/src/Listeners/CreateMailViewerItem.php
+++ b/src/Listeners/CreateMailViewerItem.php
@@ -40,7 +40,7 @@ class CreateMailViewerItem
 
         return [
             'date' => $headers->get('date'),
-            'message-id' => $headers->get('message-id')->getIds(),
+            'message-id' => $headers->get('message-id'),
             'from' => $headers->get('from'),
         ];
     }

--- a/src/Listeners/CreateMailViewerItem.php
+++ b/src/Listeners/CreateMailViewerItem.php
@@ -37,7 +37,7 @@ class CreateMailViewerItem
         if (! config('mailviewer.database.include.headers')) {
             return null;
         }
-        
+
         return [
             'date' => $headers->get('date'),
             'message-id' => $this->getMessageId($headers),
@@ -49,12 +49,16 @@ class CreateMailViewerItem
     {
         $messageId = $headers->get('message-id');
 
+        if ($messageId instanceof \Symfony\Component\Mime\Header\UnstructuredHeader) {
+            return $messageId->getBodyAsString();
+        }
+
+        if ($messageId instanceof \Symfony\Component\Mime\Header\IdentificationHeader) {
+            return $messageId->getIds();
+        }
+
         if (is_object($messageId)) {
-            return match (get_class($messageId)) {
-                \Symfony\Component\Mime\Header\UnstructuredHeader::class => $messageId->getBodyAsString(),
-                \Symfony\Component\Mime\Header\IdentificationHeader::class => $messageId->getIds(),
-                default => $messageId->toString()
-            };
+            return $messageId->toString();
         }
 
         return $messageId;

--- a/src/Listeners/CreateMailViewerItem.php
+++ b/src/Listeners/CreateMailViewerItem.php
@@ -40,7 +40,7 @@ class CreateMailViewerItem
 
         return [
             'date' => $headers->get('date'),
-            'message-id' => $headers->get('message-id'),
+            'message-id' => $headers->get('message-id')->getIds(),
             'from' => $headers->get('from'),
         ];
     }

--- a/src/Listeners/CreateMailViewerItem.php
+++ b/src/Listeners/CreateMailViewerItem.php
@@ -44,18 +44,19 @@ class CreateMailViewerItem
             'from' => $headers->get('from'),
         ];
     }
-    
+
     private function getMessageId(Headers $headers): mixed
     {
         $messageId = $headers->get('message-id');
-        
+
         if (is_object($messageId)) {
             return match (get_class($messageId)) {
                 \Symfony\Component\Mime\Header\UnstructuredHeader::class => $messageId->getBodyAsString(),
-                \Symfony\Component\Mime\Header\IdentificationHeader::class => $messageId->getIds()
+                \Symfony\Component\Mime\Header\IdentificationHeader::class => $messageId->getIds(),
+                default => $messageId->toString()
             };
         }
-        
+
         return $messageId;
     }
 

--- a/src/Listeners/CreateMailViewerItem.php
+++ b/src/Listeners/CreateMailViewerItem.php
@@ -37,12 +37,26 @@ class CreateMailViewerItem
         if (! config('mailviewer.database.include.headers')) {
             return null;
         }
-
+        
         return [
             'date' => $headers->get('date'),
-            'message-id' => $headers->get('message-id')?->getIds(),
+            'message-id' => $this->getMessageId($headers),
             'from' => $headers->get('from'),
         ];
+    }
+    
+    private function getMessageId(Headers $headers): mixed
+    {
+        $messageId = $headers->get('message-id');
+        
+        if (is_object($messageId)) {
+            return match (get_class($messageId)) {
+                \Symfony\Component\Mime\Header\UnstructuredHeader::class => $messageId->getBodyAsString(),
+                \Symfony\Component\Mime\Header\IdentificationHeader::class => $messageId->getIds()
+            };
+        }
+        
+        return $messageId;
     }
 
     private function formatRecipients(Email $message): array


### PR DESCRIPTION
As Laravel saves the Message-Id as an IdentificationHeader, $headers->get('message-id') was not working as intended in the formatHeaders method.